### PR TITLE
Add EDIM to the list of packages being tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
     - PKG_NAME=autpgrp
     - PKG_NAME=ctbllib
     - PKG_NAME=datastructures
+    - PKG_NAME=edim
     - PKG_NAME=ferret
     - PKG_NAME=format
     - PKG_NAME=fr


### PR DESCRIPTION
For some reason EDIM was tested neither in staging nor in the working
package tests. It currently won't pass tests due to a regression, and
I didn't notice because it wasn't present in these docker tests.

I submitted a fix to the EDIM package, see <https://github.com/frankluebeck/EDIM/pull/10>

See also https://github.com/gap-infra/gap-docker-pkg-tests-master/pull/3

UPDATE: Ah, I see now why EDIM is not there: Because while a test file was added in February 2018, no release of EDIM was made since then by Frank... I'll try to get him to merge my fix and then release one quickly. Let's keep this PR around till then, as a reminder?